### PR TITLE
Update notifications_handler.dart

### DIFF
--- a/fcm_config/lib/src/notifications_handler.dart
+++ b/fcm_config/lib/src/notifications_handler.dart
@@ -1,2 +1,2 @@
-export 'io_notifications_handler.dart'
+import 'io_notifications_handler.dart'
     if (dart.library.html) 'web_notification_handler.dart';


### PR DESCRIPTION
This pull request addresses an issue in the fcm_config/lib/src/notifications_handler.dart file by correcting the import statements for platform-specific notification handlers.

Changes Made:
Conditionally import io_notifications_handler.dart and web_notification_handler.dart based on the platform.
Error Fixed:
Code
Launching lib/main.dart on Chrome in debug mode...
../../.pub-cache/hosted/pub.dev/fcm_config-3.6.5/lib/src/notification_manger.dart:78:12: Error:
'PlatformNotificationHandler' is imported from both 'package:fcm_config/src/io_notifications_handler.dart'
and 'package:fcm_config/src/web_notification_handler.dart'.
This change ensures that the correct platform-specific notification handler is imported, resolving the conflict.

